### PR TITLE
#55 infer locale based on document language

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -211,6 +211,8 @@ export default {
 	},
 	created() {
 		this.loadQuizData();
+		let docLang = document.querySelector('html').getAttribute('lang');
+		this.$i18n.locale = docLang;
 	},
 };
 </script>


### PR DESCRIPTION
This pr closes #55. The app detects the page language and sets is as the default i18n locale